### PR TITLE
Update snowdog/module-menu dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "MIT"
     ],
     "require": {
-        "snowdog/module-menu": "~2.18.0"
+        "snowdog/module-menu": "~2.20.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
As `snowdog/module-menu` recently published a new version, it would be awesome, if this extension could be compatible with this one. I did not check that now in detail, but would assume, that it is compatible, so we would only need to update the requirement.